### PR TITLE
goci-1710-trait-sync-improvements Trait Sync MQ changes

### DIFF
--- a/gwas-mapping-service/src/main/resources/application-cluster.yml
+++ b/gwas-mapping-service/src/main/resources/application-cluster.yml
@@ -24,10 +24,10 @@ ensembl:
     driver-class: org.mariadb.jdbc.Driver
     url: jdbc:mysql://useastdb.ensembl.org:3306
   #db_version: '113'
-  db_version: '114'
-  #server: https://oct2024.rest.ensembl.org
-  server: https://may2025.rest.ensembl.org
-  #server: https://rest.ensembl.org/
+  db_version: '115'
+  #server: https://may2025.rest.ensembl.org
+  #server: https://may2025.rest.ensembl.org
+  server: https://rest.ensembl.org/
 
 mapping:
   dbsnp_endpoint: /info/variation/homo_sapiens?content-type=application/json;filter=dbSNP
@@ -44,7 +44,7 @@ mapping:
   requestCount: 0
   requestPerSecond: 15
   snp_lookup_endpoint: variation
-  #version: 113
-  version: 114
+  #version: 114
+  version: 115
   #cache: /Users/sajo/Downloads/cache
   cache: /nfs/gwas/data/prod/sw/mapper/ensembl-cache

--- a/gwas-mapping-service/src/main/resources/application-local.yml
+++ b/gwas-mapping-service/src/main/resources/application-local.yml
@@ -23,11 +23,11 @@ ensembl:
   datasource:
     driver-class: org.mariadb.jdbc.Driver
     url: jdbc:mysql://useastdb.ensembl.org:3306
-  #db_version: '113'
-  db_version: '114'
+  #db_version: '114'
+  db_version: '115'
   #server: https://jul2023.rest.ensembl.org
-  #server: https://oct2024.rest.ensembl.org
-  server: https://may2025.rest.ensembl.org
+  #server: https://may2025.rest.ensembl.org
+  server: https://sep2025.rest.ensembl.org
 mapping:
   dbsnp_endpoint: /info/variation/homo_sapiens?content-type=application/json;filter=dbSNP
   ensembl_source: Ensembl
@@ -43,8 +43,8 @@ mapping:
   requestCount: 0
   requestPerSecond: 15
   snp_lookup_endpoint: variation
-  #version: 113
-  version: 114
+  #version: 114
+  version: 115
   cache: /Users/sajo/Downloads/cache
   #cache: /nfs/gwas/data/prod/sw/mapper/ensembl-cache
 

--- a/gwas-rabbitmq-listener/pom.xml
+++ b/gwas-rabbitmq-listener/pom.xml
@@ -8,10 +8,9 @@
     <version>0.0.1-SNAPSHOT</version>
     <name>gwas-rabbitmq-listener</name>
     <parent>
-        <groupId>uk.ac.ebi.spot.gwasdepo</groupId>
+        <groupId>uk.ac.ebi.spot.gwas</groupId>
         <artifactId>gwasdepo-master</artifactId>
-        <version>1.0.3</version>
-        <relativePath/>
+        <version>1.0.7</version>
     </parent>
 
     <description>Maps all associations in the database using Ensembl mapping pipeline</description>
@@ -20,23 +19,11 @@
         <java.version>1.8</java.version>
     </properties>
 
-
     <repositories>
         <repository>
-            <id>spot-releases</id>
-            <name>Releases</name>
-            <url>https://wwwdev.ebi.ac.uk/gwas/nexus/repository/maven-releases/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>spot-snapshots</id>
-            <name>Snapshot</name>
-            <url>https://wwwdev.ebi.ac.uk/gwas/nexus/repository/maven-snapshots/</url>
+            <name>Central Portal Snapshots</name>
+            <id>central-portal-snapshots</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <releases>
                 <enabled>false</enabled>
             </releases>
@@ -44,36 +31,14 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
-
-       <repository>
-              <id>central</id>
-              <name>Maven Central</name>
-              <layout>default</layout>
-              <url>https://repo1.maven.org/maven2</url>
-              <snapshots>
-                  <enabled>false</enabled>
-              </snapshots>
-          </repository>
     </repositories>
 
-    <distributionManagement>
-        <repository>
-            <id>spot</id>
-            <name>Releases</name>
-            <url>https://wwwdev.ebi.ac.uk/gwas/nexus/repository/maven-releases/</url>
-        </repository>
-        <snapshotRepository>
-            <id>spot</id>
-            <name>Snapshot</name>
-            <url>https://wwwdev.ebi.ac.uk/gwas/nexus/repository/maven-snapshots/</url>
-        </snapshotRepository>
-    </distributionManagement>
 
     <dependencies>
         <dependency>
-            <groupId>uk.ac.ebi.spot.gwasdepo</groupId>
+            <groupId>uk.ac.ebi.spot.gwas</groupId>
             <artifactId>gwasdepo-commons</artifactId>
-            <version>1.0.48-SNAPSHOT</version>
+            <version>1.0.49-SNAPSHOT</version>
            <exclusions>
                 <exclusion>
                     <groupId>com.zaxxer</groupId>
@@ -85,7 +50,7 @@
         <dependency>
             <groupId>uk.ac.ebi.spot.gwas</groupId>
             <artifactId>gwas-data-commons</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>1.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/config/DiseaseTraitMQConfiguration.java
+++ b/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/config/DiseaseTraitMQConfiguration.java
@@ -1,0 +1,32 @@
+package uk.ac.ebi.spot.gwas.rabbitmq.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import uk.ac.ebi.spot.gwas.deposition.config.DiseaseTraitMQConfigProperties;
+
+@Configuration
+public class DiseaseTraitMQConfiguration {
+
+    @Autowired
+    DiseaseTraitMQConfigProperties diseaseTraitMQConfigProperties;
+
+    @Bean
+    Queue diseaseTraitQueue() {
+        return new Queue(diseaseTraitMQConfigProperties.getDiseasetraitQueueName());
+    }
+
+    @Bean
+    DirectExchange diseaseTraitExchange() {
+        return new DirectExchange(diseaseTraitMQConfigProperties.getDiseasetraitExchangeName());
+    }
+
+    @Bean
+    Binding diseaseTraitBinding(Queue diseaseTraitQueue, DirectExchange diseaseTraitExchange) {
+        return BindingBuilder.bind(diseaseTraitQueue).to(diseaseTraitExchange).with(diseaseTraitMQConfigProperties.getDiseasetraitRoutingKey());
+    }
+}

--- a/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/config/EfoTraitMQConfiguration.java
+++ b/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/config/EfoTraitMQConfiguration.java
@@ -1,0 +1,28 @@
+package uk.ac.ebi.spot.gwas.rabbitmq.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import uk.ac.ebi.spot.gwas.deposition.config.EFOTraitMQConfigProperties;
+
+@Configuration
+public class EfoTraitMQConfiguration {
+
+    @Autowired
+    EFOTraitMQConfigProperties efoTraitMQConfigProperties;
+
+    @Bean
+    Queue efoTraitQueue() {return new Queue(efoTraitMQConfigProperties.getEfoTraitQueueName()); }
+
+    @Bean
+    DirectExchange efoTraitExchange() {return new DirectExchange(efoTraitMQConfigProperties.getEfoTraitExchangeName()); }
+
+    @Bean
+    Binding efoTraitBinding(Queue efoTraitQueue, DirectExchange efoTraitExchange) {
+        return BindingBuilder.bind(efoTraitQueue).to(efoTraitExchange).with(efoTraitMQConfigProperties.getEfoTraitExchangeName());
+    }
+}

--- a/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/config/PublicationMQConfiguration.java
+++ b/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/config/PublicationMQConfiguration.java
@@ -10,7 +10,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import uk.ac.ebi.spot.gwas.deposition.config.PublicationMQConfigProperties;
+import uk.ac.ebi.spot.gwas.deposition.dto.curation.DiseaseTraitRabbitMessage;
 import uk.ac.ebi.spot.gwas.deposition.dto.curation.PublicationRabbitMessage;
+import uk.ac.ebi.spot.gwas.deposition.dto.curation.EfoTraitRabbitMessage;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,6 +22,7 @@ public class PublicationMQConfiguration {
 
     @Autowired
     PublicationMQConfigProperties publicationMQConfigProperties;
+
 
     @Bean
     Queue publicationQueue(){
@@ -48,6 +51,8 @@ public class PublicationMQConfiguration {
         DefaultClassMapper classMapper = new DefaultClassMapper();
         Map<String, Class<?>> idClassMapping = new HashMap<>();
         idClassMapping.put("publicationRabbitMessage", PublicationRabbitMessage.class);
+        idClassMapping.put("efoTraitRabbitMessage", EfoTraitRabbitMessage.class);
+        idClassMapping.put("diseaseTraitRabbitMessage", DiseaseTraitRabbitMessage.class);
         classMapper.setIdClassMapping(idClassMapping);
         classMapper.setDefaultType(Map.class);
         classMapper.setTrustedPackages("*");

--- a/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/constants/DepositionCurationConstants.java
+++ b/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/constants/DepositionCurationConstants.java
@@ -7,5 +7,11 @@ public class DepositionCurationConstants {
     public static final String QUEUE_PUBLICATION_SANDBOX = "publication-sandbox";
     public static final String QUEUE_PUBLICATION_PROD = "publication";
 
+    public static final String QUEUE_EFOTRAIT_SANDBOX = "efotrait-sandbox";
+    public static final String QUEUE_EFOTRAIT_PROD = "efotrait";
+
+
+    public static final String QUEUE_DISEASETRAIT_SANDBOX = "diseasetrait-sandbox";
+    public static final String QUEUE_DISEASETRAIT_PROD = "diseasetrait";
 
 }

--- a/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/consumer/DiseaseTraitRabbitConsumer.java
+++ b/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/consumer/DiseaseTraitRabbitConsumer.java
@@ -1,0 +1,61 @@
+package uk.ac.ebi.spot.gwas.rabbitmq.consumer;
+
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.ac.ebi.spot.gwas.deposition.dto.curation.DiseaseTraitRabbitMessage;
+import uk.ac.ebi.spot.gwas.deposition.messaging.email.EmailService;
+import uk.ac.ebi.spot.gwas.rabbitmq.config.BackendEmailConfig;
+import uk.ac.ebi.spot.gwas.rabbitmq.constants.DepositionCurationConstants;
+import uk.ac.ebi.spot.gwas.rabbitmq.service.DiseaseTraitImportService;
+
+@Slf4j
+@Component
+public class DiseaseTraitRabbitConsumer {
+
+    private final Logger bsubLog = LoggerFactory.getLogger("bsublogger");
+
+    @Autowired
+    DiseaseTraitImportService diseaseTraitImportService;
+
+
+    @Autowired
+    EmailService emailService;
+
+    @Autowired
+    BackendEmailConfig backendEmailConfig;
+
+
+    @RabbitListener(queues = {DepositionCurationConstants.QUEUE_DISEASETRAIT_SANDBOX,
+            DepositionCurationConstants.QUEUE_DISEASETRAIT_PROD})
+    public void listen(DiseaseTraitRabbitMessage diseaseTraitRabbitMessage) {
+        try {
+            log.info("Consuming message for diseaseTraitRabbitMessage : {}", diseaseTraitRabbitMessage.getTrait());
+            diseaseTraitImportService.importDiseaseTrait(diseaseTraitRabbitMessage);
+        } catch (Exception ex) {
+            log.error("Error in consuming message for diseaseTraitRabbitMessage" + ex.getMessage(), ex);
+            String content = "";
+            String subject = "";
+            if (diseaseTraitRabbitMessage.getTrait() != null) {
+                content = String.format("DiseaseTrait import failed for %s %s %s", diseaseTraitRabbitMessage.getTrait(), ex.getMessage(), ex);
+                subject = String.format("DiseaseTrait Rabbit consumer - Error encountered import failed for %s", diseaseTraitRabbitMessage.getTrait());
+            } else {
+                content = String.format("DiseaseTrait import failed %s %s", ex.getMessage(), ex);
+                subject = "DiseaseTrait Rabbit consumer - Error encountered import failed";
+            }
+
+            for (String emailAddress : backendEmailConfig.getToAddress().split(",")) {
+                if (diseaseTraitRabbitMessage.getTrait() != null) {
+                    log.info("DiseaseTrait import failed for {}", diseaseTraitRabbitMessage.getTrait());
+                    bsubLog.info("DiseaseTrait Rabbit consumer - Error encountered import failed for {}", diseaseTraitRabbitMessage.getTrait());
+                }
+                emailService.sendMessage(emailAddress, subject, content, false);
+            }
+        }
+
+    }
+
+}

--- a/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/consumer/EfoTraitProdRabbitConsumer.java
+++ b/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/consumer/EfoTraitProdRabbitConsumer.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import uk.ac.ebi.spot.gwas.deposition.dto.curation.EfoTraitRabbitMessage;
 import uk.ac.ebi.spot.gwas.deposition.messaging.email.EmailService;
@@ -14,7 +15,8 @@ import uk.ac.ebi.spot.gwas.rabbitmq.service.EfoTraitImportService;
 
 @Slf4j
 @Component
-public class EfoTraitRabbitConsumer {
+@Profile({"cluster","fallback"})
+public class EfoTraitProdRabbitConsumer {
 
     private final Logger bsubLog = LoggerFactory.getLogger("bsublogger");
 
@@ -28,8 +30,7 @@ public class EfoTraitRabbitConsumer {
     BackendEmailConfig backendEmailConfig;
 
 
-    @RabbitListener(queues = {DepositionCurationConstants.QUEUE_EFOTRAIT_SANDBOX,
-            DepositionCurationConstants.QUEUE_EFOTRAIT_PROD})
+    @RabbitListener(queues = {DepositionCurationConstants.QUEUE_EFOTRAIT_PROD})
     public void listen(EfoTraitRabbitMessage efoTraitRabbitMessage) {
         try {
             log.info("Consuming message for efoTraitRabbitMessage : {}", efoTraitRabbitMessage.getShortForm());

--- a/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/consumer/EfoTraitRabbitConsumer.java
+++ b/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/consumer/EfoTraitRabbitConsumer.java
@@ -1,0 +1,58 @@
+package uk.ac.ebi.spot.gwas.rabbitmq.consumer;
+
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.ac.ebi.spot.gwas.deposition.dto.curation.EfoTraitRabbitMessage;
+import uk.ac.ebi.spot.gwas.deposition.messaging.email.EmailService;
+import uk.ac.ebi.spot.gwas.rabbitmq.config.BackendEmailConfig;
+import uk.ac.ebi.spot.gwas.rabbitmq.constants.DepositionCurationConstants;
+import uk.ac.ebi.spot.gwas.rabbitmq.service.EfoTraitImportService;
+
+@Slf4j
+@Component
+public class EfoTraitRabbitConsumer {
+
+    private final Logger bsubLog = LoggerFactory.getLogger("bsublogger");
+
+    @Autowired
+    EfoTraitImportService efoTraitImportService;
+
+    @Autowired
+    EmailService emailService;
+
+    @Autowired
+    BackendEmailConfig backendEmailConfig;
+
+
+    @RabbitListener(queues = {DepositionCurationConstants.QUEUE_EFOTRAIT_SANDBOX,
+            DepositionCurationConstants.QUEUE_EFOTRAIT_PROD})
+    public void listen(EfoTraitRabbitMessage efoTraitRabbitMessage) {
+        try {
+            log.info("Consuming message for efoTraitRabbitMessage : {}", efoTraitRabbitMessage.getShortForm());
+            efoTraitImportService.importEfoTrait(efoTraitRabbitMessage);
+        } catch (Exception ex) {
+            log.error("Error in consuming message for efoTraitRabbitMessage" + ex.getMessage(), ex);
+            String content = "";
+            String subject = "";
+            if (efoTraitRabbitMessage.getShortForm() != null) {
+                content = String.format("Efo import failed for %s %s %s", efoTraitRabbitMessage.getShortForm(), ex.getMessage(), ex);
+                subject = String.format("Efo Rabbit consumer - Error encountered import failed for %s", efoTraitRabbitMessage.getShortForm());
+            } else {
+                content = String.format("Efo import failed %s %s", ex.getMessage(), ex);
+                subject = "EFO Rabbit consumer - Error encountered import failed";
+            }
+
+            for (String emailAddress : backendEmailConfig.getToAddress().split(",")) {
+                if (efoTraitRabbitMessage.getShortForm() != null) {
+                    log.info("EFO import failed for {}", efoTraitRabbitMessage.getShortForm());
+                    bsubLog.info("GWAS Rabbit consumer - Error encountered import failed for {}", efoTraitRabbitMessage.getShortForm());
+                }
+                emailService.sendMessage(emailAddress, subject, content, false);
+            }
+        }
+    }
+}

--- a/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/consumer/EfoTraitSandboxRabbitConsumer.java
+++ b/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/consumer/EfoTraitSandboxRabbitConsumer.java
@@ -1,0 +1,59 @@
+package uk.ac.ebi.spot.gwas.rabbitmq.consumer;
+
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import uk.ac.ebi.spot.gwas.deposition.dto.curation.EfoTraitRabbitMessage;
+import uk.ac.ebi.spot.gwas.deposition.messaging.email.EmailService;
+import uk.ac.ebi.spot.gwas.rabbitmq.config.BackendEmailConfig;
+import uk.ac.ebi.spot.gwas.rabbitmq.constants.DepositionCurationConstants;
+import uk.ac.ebi.spot.gwas.rabbitmq.service.EfoTraitImportService;
+
+@Slf4j
+@Component
+@Profile({"sandbox-migration", "local"})
+public class EfoTraitSandboxRabbitConsumer {
+
+    private final Logger bsubLog = LoggerFactory.getLogger("bsublogger");
+
+    @Autowired
+    EfoTraitImportService efoTraitImportService;
+
+    @Autowired
+    EmailService emailService;
+
+    @Autowired
+    BackendEmailConfig backendEmailConfig;
+
+
+    @RabbitListener(queues = {DepositionCurationConstants.QUEUE_EFOTRAIT_SANDBOX})
+    public void listen(EfoTraitRabbitMessage efoTraitRabbitMessage) {
+        try {
+            log.info("Consuming message for efoTraitRabbitMessage : {}", efoTraitRabbitMessage.getShortForm());
+            efoTraitImportService.importEfoTrait(efoTraitRabbitMessage);
+        } catch (Exception ex) {
+            log.error("Error in consuming message for efoTraitRabbitMessage" + ex.getMessage(), ex);
+            String content = "";
+            String subject = "";
+            if (efoTraitRabbitMessage.getShortForm() != null) {
+                content = String.format("Efo import failed for %s %s %s", efoTraitRabbitMessage.getShortForm(), ex.getMessage(), ex);
+                subject = String.format("Efo Rabbit consumer - Error encountered import failed for %s", efoTraitRabbitMessage.getShortForm());
+            } else {
+                content = String.format("Efo import failed %s %s", ex.getMessage(), ex);
+                subject = "EFO Rabbit consumer - Error encountered import failed";
+            }
+
+            for (String emailAddress : backendEmailConfig.getToAddress().split(",")) {
+                if (efoTraitRabbitMessage.getShortForm() != null) {
+                    log.info("EFO import failed for {}", efoTraitRabbitMessage.getShortForm());
+                    bsubLog.info("GWAS Rabbit consumer - Error encountered import failed for {}", efoTraitRabbitMessage.getShortForm());
+                }
+                emailService.sendMessage(emailAddress, subject, content, false);
+            }
+        }
+    }
+}

--- a/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/dto/DiseaseTraitRabbitMessageAssembler.java
+++ b/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/dto/DiseaseTraitRabbitMessageAssembler.java
@@ -1,0 +1,17 @@
+package uk.ac.ebi.spot.gwas.rabbitmq.dto;
+
+import org.springframework.stereotype.Component;
+import uk.ac.ebi.spot.gwas.deposition.dto.curation.DiseaseTraitRabbitMessage;
+import uk.ac.ebi.spot.gwas.model.DiseaseTrait;
+
+@Component
+public class DiseaseTraitRabbitMessageAssembler {
+
+    public DiseaseTrait  disassemble(DiseaseTraitRabbitMessage diseaseTraitRabbitMessage) {
+        DiseaseTrait diseaseTrait = new DiseaseTrait();
+        diseaseTrait.setTrait(diseaseTraitRabbitMessage.getTrait());
+        diseaseTrait.setMongoSeqId(diseaseTraitRabbitMessage.getMongoSeqId());
+        return diseaseTrait;
+    }
+
+}

--- a/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/dto/EFOTraitRabbitMessageAssembler.java
+++ b/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/dto/EFOTraitRabbitMessageAssembler.java
@@ -1,0 +1,18 @@
+package uk.ac.ebi.spot.gwas.rabbitmq.dto;
+
+import org.springframework.stereotype.Component;
+import uk.ac.ebi.spot.gwas.deposition.dto.curation.EfoTraitRabbitMessage;
+import uk.ac.ebi.spot.gwas.model.EfoTrait;
+
+@Component
+public class EFOTraitRabbitMessageAssembler {
+
+    public EfoTrait disassemble(EfoTraitRabbitMessage efoTraitRabbitMessage) {
+        EfoTrait efoTrait = new EfoTrait();
+        efoTrait.setTrait(efoTraitRabbitMessage.getTrait());
+        efoTrait.setShortForm(efoTraitRabbitMessage.getShortForm());
+        efoTrait.setMongoSeqId(efoTraitRabbitMessage.getMongoSeqId());
+        efoTrait.setUri(efoTraitRabbitMessage.getUri());
+        return efoTrait;
+    }
+}

--- a/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/repository/AssociationRepository.java
+++ b/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/repository/AssociationRepository.java
@@ -112,4 +112,6 @@ public interface AssociationRepository extends JpaRepository<Association, Long> 
 
 
     Page<Association> findByStudyPublicationIdPubmedId(String pubmedId, Pageable pageable);
+
+    Collection<Association> findByParentEfoTraitsId(Long efoTraitId);
 }

--- a/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/repository/EfoTraitRepository.java
+++ b/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/repository/EfoTraitRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import uk.ac.ebi.spot.gwas.model.EfoTrait;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Created by emma on 04/12/14.
@@ -66,7 +67,7 @@ public interface EfoTraitRepository extends JpaRepository<EfoTrait, Long> {
 
     EfoTrait findByShortForm(String shortForm);
 
-    EfoTrait findByMongoSeqId(String mongoSeqId);
+    Optional<EfoTrait> findByMongoSeqId(String mongoSeqId);
 
 
     Page<EfoTrait> findByStudiesPublicationIdPubmedId(String pumbedId, Pageable pageable);

--- a/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/repository/StudyRepository.java
+++ b/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/repository/StudyRepository.java
@@ -181,5 +181,8 @@ public interface StudyRepository extends JpaRepository<Study, Long>, JpaSpecific
 
     Page<Study> findAll(Pageable pageable);
 
+
+    Collection<Study> findByParentStudyEfoTraitsId(Long efoTraitId);
+
 }
 

--- a/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/service/DiseaseTraitImportService.java
+++ b/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/service/DiseaseTraitImportService.java
@@ -1,0 +1,8 @@
+package uk.ac.ebi.spot.gwas.rabbitmq.service;
+
+import uk.ac.ebi.spot.gwas.deposition.dto.curation.DiseaseTraitRabbitMessage;
+
+public interface DiseaseTraitImportService {
+
+     void importDiseaseTrait(DiseaseTraitRabbitMessage traitRabbitMessage);
+}

--- a/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/service/EfoTraitImportService.java
+++ b/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/service/EfoTraitImportService.java
@@ -1,0 +1,8 @@
+package uk.ac.ebi.spot.gwas.rabbitmq.service;
+
+import uk.ac.ebi.spot.gwas.deposition.dto.curation.EfoTraitRabbitMessage;
+
+public interface EfoTraitImportService {
+
+    void importEfoTrait(EfoTraitRabbitMessage efoTraitRabbitMessage);
+}

--- a/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/service/impl/DiseaseTraitImportServiceImpl.java
+++ b/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/service/impl/DiseaseTraitImportServiceImpl.java
@@ -1,0 +1,53 @@
+package uk.ac.ebi.spot.gwas.rabbitmq.service.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import uk.ac.ebi.spot.gwas.deposition.dto.curation.DiseaseTraitRabbitMessage;
+import uk.ac.ebi.spot.gwas.model.DiseaseTrait;
+import uk.ac.ebi.spot.gwas.rabbitmq.dto.DiseaseTraitRabbitMessageAssembler;
+import uk.ac.ebi.spot.gwas.rabbitmq.repository.DiseaseTraitRepository;
+import uk.ac.ebi.spot.gwas.rabbitmq.repository.StudyRepository;
+import uk.ac.ebi.spot.gwas.rabbitmq.service.DiseaseTraitImportService;
+
+import java.util.Optional;
+
+@Service
+public class DiseaseTraitImportServiceImpl implements DiseaseTraitImportService {
+
+    @Autowired
+    DiseaseTraitRabbitMessageAssembler diseaseTraitRabbitMessageAssembler;
+
+    @Autowired
+    DiseaseTraitRepository diseaseTraitRepository;
+
+    @Autowired
+    StudyRepository studyRepository;
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void importDiseaseTrait(DiseaseTraitRabbitMessage diseaseTraitRabbitMessage) {
+        if(diseaseTraitRabbitMessage.getOperation().equals("insert")) {
+            DiseaseTrait diseaseTrait = diseaseTraitRabbitMessageAssembler.disassemble(diseaseTraitRabbitMessage);
+            diseaseTraitRepository.save(diseaseTrait);
+        } else if(diseaseTraitRabbitMessage.getOperation().equals("update")) {
+            DiseaseTrait diseaseTrait =   getDiseaseTrait(diseaseTraitRabbitMessage.getMongoSeqId());
+            diseaseTrait.setTrait(Optional.ofNullable(diseaseTraitRabbitMessage.getTrait()).orElse(diseaseTrait.getTrait()));
+            diseaseTraitRepository.save(diseaseTrait);
+        } else if(diseaseTraitRabbitMessage.getOperation().equals("delete")) {
+            DiseaseTrait diseaseTrait  = getDiseaseTrait(diseaseTraitRabbitMessage.getMongoSeqId());
+            if(diseaseTrait != null) {
+                studyRepository.findByDiseaseTraitId(diseaseTrait.getId()).forEach(study -> {
+                    study.setDiseaseTrait(null);
+                    study.setBackgroundTrait(null);
+                    studyRepository.save(study);
+                });
+                diseaseTraitRepository.delete(diseaseTrait);
+            }
+        }
+    }
+
+   private DiseaseTrait getDiseaseTrait(String mongoSeqId) {
+        return diseaseTraitRepository.findByMongoSeqId(mongoSeqId).orElse(null);
+    }
+}

--- a/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/service/impl/EfoTraitImportServiceImpl.java
+++ b/gwas-rabbitmq-listener/src/main/java/uk/ac/ebi/spot/gwas/rabbitmq/service/impl/EfoTraitImportServiceImpl.java
@@ -1,0 +1,132 @@
+package uk.ac.ebi.spot.gwas.rabbitmq.service.impl;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import uk.ac.ebi.spot.gwas.deposition.dto.curation.EfoTraitRabbitMessage;
+import uk.ac.ebi.spot.gwas.model.EfoTrait;
+import uk.ac.ebi.spot.gwas.rabbitmq.dto.EFOTraitRabbitMessageAssembler;
+import uk.ac.ebi.spot.gwas.rabbitmq.repository.AssociationRepository;
+import uk.ac.ebi.spot.gwas.rabbitmq.repository.EfoTraitRepository;
+import uk.ac.ebi.spot.gwas.rabbitmq.repository.StudyRepository;
+import uk.ac.ebi.spot.gwas.rabbitmq.service.EfoTraitImportService;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+public class EfoTraitImportServiceImpl implements EfoTraitImportService {
+
+    @Autowired
+    EFOTraitRabbitMessageAssembler efoTraitRabbitMessageAssembler ;
+
+    @Autowired
+    EfoTraitRepository efoTraitRepository;
+
+    @Autowired
+    StudyRepository studyRepository;
+
+    @Autowired
+    AssociationRepository associationRepository;
+
+
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void importEfoTrait(EfoTraitRabbitMessage efoTraitRabbitMessage) {
+
+        if(efoTraitRabbitMessage.getOperation().equalsIgnoreCase("insert")) {
+            EfoTrait efoTrait = efoTraitRabbitMessageAssembler.disassemble(efoTraitRabbitMessage);
+            saveEfoTrait(efoTrait);
+        }else if(efoTraitRabbitMessage.getOperation().equalsIgnoreCase("update")) {
+            EfoTrait efoTrait =  getEfoTrait(efoTraitRabbitMessage.getMongoSeqId());
+            if(efoTrait != null) {
+                efoTrait.setTrait(Optional.ofNullable(efoTraitRabbitMessage.getTrait()).orElse(efoTrait.getTrait()));
+                efoTrait.setShortForm(Optional.ofNullable(efoTraitRabbitMessage.getShortForm()).orElse(efoTrait.getShortForm()));
+                efoTrait.setUri(Optional.ofNullable(efoTraitRabbitMessage.getUri()).orElse(efoTrait.getUri()));
+                saveEfoTrait(efoTrait);
+            }
+        }else if(efoTraitRabbitMessage.getOperation().equalsIgnoreCase("delete")) {
+            try {
+                removeStudyEFOMapping(efoTraitRabbitMessage.getMongoSeqId());
+            }catch(Exception ex){
+                log.error("Exception with EFO Trait SeqId -: {} ",efoTraitRabbitMessage.getMongoSeqId());
+                log.error("Exception in syncEFOTraits Delete ()"+ex.getMessage(),ex );
+
+            }
+        }
+
+    }
+
+    void saveEfoTrait(EfoTrait efoTrait) {
+        efoTraitRepository.save(efoTrait);
+    }
+
+    void updateEfoTrait(EfoTrait efoTrait) {
+        efoTraitRepository.save(efoTrait);
+    }
+
+    EfoTrait getEfoTrait(String mongoSeqId) {
+        return efoTraitRepository.findByMongoSeqId(mongoSeqId).orElse(null);
+    }
+
+    void deleteEfoTrait(EfoTrait efoTrait) {
+        efoTraitRepository.delete(efoTrait);
+    }
+
+    @Transactional(propagation = Propagation.SUPPORTS)
+    public void removeStudyEFOMapping( String seqId) {
+
+        log.info("Mongo Ids to be deleted {}", seqId);
+        efoTraitRepository.findByMongoSeqId(seqId).ifPresent(efoTrait -> {
+
+            log.info("Trait which is deleted is {}", efoTrait.getShortForm());
+            log.info("Trait ID which is deleted is {}", efoTrait.getId());
+            log.info("Size of the study list" +studyRepository.findByEfoTraitsId(efoTrait.getId()).size());
+            studyRepository.findByEfoTraitsId(efoTrait.getId()).forEach(study -> {
+                //study.setEfoTraits(null);
+                log.info("Calling removeStudyEFOMappings()");
+                study.getEfoTraits().remove(efoTrait);
+                studyRepository.save(study);
+            });
+
+            studyRepository.findByParentStudyEfoTraitsId(efoTrait.getId()).forEach(study -> {
+                log.info("Calling removeParentStudyEFOMappings()");
+                study.getParentStudyEfoTraits().remove(efoTrait);
+                studyRepository.save(study);
+            });
+            studyRepository.findByMappedBackgroundTraitsId(efoTrait.getId()).forEach(study -> {
+                //study.setEfoTraits(null);
+                log.info("Calling removeStudyBGEFOMappings()");
+                study.getMappedBackgroundTraits().remove(efoTrait);
+                studyRepository.save(study);
+            });
+
+
+            associationRepository.findByEfoTraitsId(efoTrait.getId()).forEach(asscn -> {
+                //asscn.setEfoTraits(null);
+                log.info("Calling removeAsscnEFOMappings()");
+                asscn.getEfoTraits().remove(efoTrait);
+                associationRepository.save(asscn);
+            });
+            associationRepository.findByParentEfoTraitsId(efoTrait.getId()).forEach(asscn -> {
+                log.info("Calling removeParentAsscnEFOMappings()");
+                asscn.getParentEfoTraits().remove(efoTrait);
+                associationRepository.save(asscn);
+            });
+            associationRepository.findByBkgEfoTraitsId(efoTrait.getId()).forEach(asscn -> {
+                //asscn.setEfoTraits(null);
+                log.info("Calling removeAsscnBGEFOMappings()");
+                asscn.getBkgEfoTraits().remove(efoTrait);
+                associationRepository.save(asscn);
+            });
+
+            efoTrait.getParentChildEfoTraits().remove(efoTrait);
+            deleteEfoTrait(efoTrait);
+            //efoTraitService.delete(efoTrait);
+        });
+    }
+
+
+}

--- a/gwas-rabbitmq-listener/src/main/resources/application-cluster.yml
+++ b/gwas-rabbitmq-listener/src/main/resources/application-cluster.yml
@@ -49,6 +49,14 @@ rabbitmq:
     queue-name: publication-sandbox
     exchange-name: publication-exchange-sandbox
     routing-key: publication-route-sandbox
+  efotrait:
+    queue-name: efotrait
+    exchange-name: efotrait-exchange
+    routing-key: efotrait-route
+  diseasetrait:
+    queue-name: diseasetrait
+    exchange-name: diseasetrait-exchange
+    routing-key: diseasetrait-route
   dead-letter:
     queue-name: dead-letter-queue
     exchange-name: dead-letter-exchange

--- a/gwas-rabbitmq-listener/src/main/resources/application-fallback.yml
+++ b/gwas-rabbitmq-listener/src/main/resources/application-fallback.yml
@@ -49,6 +49,14 @@ rabbitmq:
     queue-name: publication-sandbox
     exchange-name: publication-exchange-sandbox
     routing-key: publication-route-sandbox
+  efotrait:
+    queue-name: efotrait
+    exchange-name: efotrait-exchange
+    routing-key: efotrait-route
+  diseasetrait:
+    queue-name: diseasetrait
+    exchange-name: diseasetrait-exchange
+    routing-key: diseasetrait-route
   dead-letter:
     queue-name: dead-letter-queue
     exchange-name: dead-letter-exchange

--- a/gwas-rabbitmq-listener/src/main/resources/application-local.yml
+++ b/gwas-rabbitmq-listener/src/main/resources/application-local.yml
@@ -8,8 +8,8 @@ spring:
     port: 5672
 
   datasource:
-    #url: jdbc:oracle:thin:@ora-spot-dev2-hl.ebi.ac.uk:1521/SPOTDV2
-    url: jdbc:oracle:thin:@ora-spot-pro-hl.ebi.ac.uk:1531/SPOTPRO
+    url: jdbc:oracle:thin:@ora-spot-dev2-hl.ebi.ac.uk:1521/SPOTDV2
+   #url: jdbc:oracle:thin:@ora-spot-pro-hl.ebi.ac.uk:1531/SPOTPRO
     username:
     password: 
     driver-class-name: oracle.jdbc.driver.OracleDriver
@@ -52,3 +52,11 @@ rabbitmq:
     queue-name: publication-sandbox
     exchange-name: publication-exchange-sandbox
     routing-key: publication-route-sandbox
+  efotrait:
+    queue-name: efotrait-sandbox
+    exchange-name: efotrait-exchange-sandbox
+    routing-key: efotrait-route-sandbox
+  diseasetrait:
+    queue-name: diseasetrait-sandbox
+    exchange-name: diseasetrait-exchange-sandbox
+    routing-key: diseasetrait-route-sandbox

--- a/gwas-rabbitmq-listener/src/main/resources/application-sandbox-migration.yml
+++ b/gwas-rabbitmq-listener/src/main/resources/application-sandbox-migration.yml
@@ -1,0 +1,63 @@
+server:
+  port: 8685
+
+
+spring:
+  rabbitmq:
+    host: hh-rke-wp-webadmin-09-worker-1.caas.ebi.ac.uk
+    port: 30672
+    username:
+    password:
+  datasource:
+    url: jdbc:oracle:thin:@ora-spot-dev2-hl.ebi.ac.uk:1521/SPOTDV2
+   #url: jdbc:oracle:thin:@ora-spot-pro-hl.ebi.ac.uk:1531/SPOTPRO
+    username:
+    password: 
+    driver-class-name: oracle.jdbc.driver.OracleDriver
+   #hikari:
+      #maximumPoolSize: 80
+  jpa:
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        jdbc:
+          batch_size: 10
+
+
+email-config:
+  #to-address: gwas-curator@ebi.ac.uk,gwas-dev-logs@ebi.ac.uk
+  to-address: sajo@ebi.ac.uk,sajo@ebi.ac.uk
+
+executor:
+  thread-pool:
+    count:
+
+association:
+  partition:
+    size:
+
+gwas-curation:
+  #db: deposition-backend-sandbox
+  db: gwasdepo
+
+rabbitmq:
+  queue-name: study_change_sandbox
+  exchange-name: study_change_exchange_sandbox
+  routing-key: study-ingest_sandbox
+  sumstats:
+    queue-name: metadata-yml-update-sandbox
+    exchange-name: metadata-yml-update-exchange-sandbox
+    routing-key: metadata-yml-update-route-sandbox
+  publication:
+    queue-name: publication-sandbox
+    exchange-name: publication-exchange-sandbox
+    routing-key: publication-route-sandbox
+  efotrait:
+    queue-name: efotrait-sandbox
+    exchange-name: efotrait-exchange-sandbox
+    routing-key: efotrait-route-sandbox
+  diseasetrait:
+    queue-name: diseasetrait-sandbox
+    exchange-name: diseasetrait-exchange-sandbox
+    routing-key: diseasetrait-route-sandbox

--- a/gwas-rabbitmq-listener/src/main/resources/logback-spring.xml
+++ b/gwas-rabbitmq-listener/src/main/resources/logback-spring.xml
@@ -153,6 +153,155 @@
     </springProfile>
 
 
+    <springProfile name="sandbox-migration">
+        <property resource="logging-cluster.properties"/>
+        <property name="LOG_PATH" value="${log.file.location}/logs" />
+        <appender name="Console"
+                  class="ch.qos.logback.core.ConsoleAppender">
+            <layout class="ch.qos.logback.classic.PatternLayout">
+                <Pattern>
+                    %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
+                </Pattern>
+            </layout>
+        </appender>
+
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <!-- <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                 <level>WARN</level>
+                 <onMatch>DENY</onMatch>
+             </filter>-->
+            <encoder>
+                <pattern>${LOG_PATTERN}</pattern>
+            </encoder>
+        </appender>
+
+        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <!--<filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>INFO</level>
+            </filter>
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>WARN</level>
+                <onMatch>DENY</onMatch>
+            </filter>
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>ERROR</level>
+                <onMatch>DENY</onMatch>
+            </filter>-->
+
+            <encoder>
+                <pattern>${LOG_PATTERN}</pattern>
+            </encoder>
+            <!--current log file-->
+            <file>${LOG_PATH}/gwas-rabbitmq-listener-sandbox-status.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <!-- rollover daily -->
+                <fileNamePattern>${LOG_PATH}/was-rabbitmq-listener-sandbox-status.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <!--determines when we rollover-->
+                <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                    <maxFileSize>20MB</maxFileSize>
+                </timeBasedFileNamingAndTriggeringPolicy>
+                <maxHistory>50</maxHistory>
+            </rollingPolicy>
+        </appender>
+
+        <appender name="FILE_DEBUG" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>DEBUG</level>
+            </filter>
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>WARN</level>
+                <onMatch>DENY</onMatch>
+            </filter>
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>INFO</level>
+                <onMatch>DENY</onMatch>
+            </filter>
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>ERROR</level>
+                <onMatch>DENY</onMatch>
+            </filter>
+
+            <encoder>
+                <pattern>${LOG_PATTERN}</pattern>
+            </encoder>
+            <!--current log file-->
+            <file>${LOG_PATH}/gwas-rabbitmq-listener-sandbox-debug.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <!-- rollover daily -->
+                <fileNamePattern>${LOG_PATH}/gwas-rabbitmq-listener-sandbox-debug.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <!--determines when we rollover-->
+                <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                    <maxFileSize>20MB</maxFileSize>
+                </timeBasedFileNamingAndTriggeringPolicy>
+                <maxHistory>50</maxHistory>
+            </rollingPolicy>
+        </appender>
+
+        <appender name="FILE_ERR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>ERROR</level>
+            </filter>
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>INFO</level>
+                <onMatch>DENY</onMatch>
+            </filter>
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>WARN</level>
+                <onMatch>DENY</onMatch>
+            </filter>
+
+            <encoder>
+                <pattern>${LOG_PATTERN}</pattern>
+            </encoder>
+            <!--current log file-->
+            <file>${LOG_PATH}/gwas-rabbitmq-listener-sandbox.severe.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <!-- rollover daily -->
+                <fileNamePattern>${LOG_PATH}/gwas-rabbitmq-listener.severe.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <!--determines when we rollover-->
+                <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                    <maxFileSize>20MB</maxFileSize>
+                </timeBasedFileNamingAndTriggeringPolicy>
+                <maxHistory>50</maxHistory>
+            </rollingPolicy>
+        </appender>
+        <appender name="bsubloggerAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+
+            <encoder>
+                <pattern>${LOG_PATTERN}</pattern>
+            </encoder>
+            <!--current log file-->
+            <file>${LOG_PATH}/gwas-rabbitmq-listener-sandbox-failed.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <!-- rollover daily -->
+                <fileNamePattern>${LOG_PATH}/gwas-rabbitmq-listener-sandbox-failed.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <!--determines when we rollover-->
+                <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                    <maxFileSize>20MB</maxFileSize>
+                </timeBasedFileNamingAndTriggeringPolicy>
+                <maxHistory>5000</maxHistory>
+            </rollingPolicy>
+        </appender>
+        <root level="error">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
+        </root>
+        <logger name="bsublogger" level="INFO" additivity="false">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="bsubloggerAppender"/>
+        </logger>
+
+
+        <logger name="uk.ac.ebi.spot.gwas" level="INFO" additivity="false">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
+            <appender-ref ref="FILE_DEBUG"/>
+            <appender-ref ref="FILE_ERR"/>
+        </logger>
+    </springProfile>
+
+
+
     <springProfile name="fallback">
         <property resource="logging-cluster.properties"/>
         <property name="LOG_PATH" value="${log.file.location}/logs" />


### PR DESCRIPTION
The PR is linked to the below tickets 
[https://github.com/EBISPOT/goci/issues/1710](https://github.com/EBISPOT/goci/issues/1710)

The changes includes creating a message queue for handling messages for EFO Trait & Reported Trait changes . Existing rabbitmq queues are used , the consumer is running at codon cluster & listens to incoming messages & updates oracle at near real time basis, An email will be sent to curators in case the message consuming fails  